### PR TITLE
Bugfix - tipagem da propriedade port da classe Uri, adicionado o tipo…

### DIFF
--- a/src/Http/Uri.php
+++ b/src/Http/Uri.php
@@ -14,7 +14,7 @@ class Uri implements UriInterface
     private string $scheme = '';
     private string $userInfo = '';
     private string $host = '';
-    private string|int $port = '';
+    private string|int|null $port = '';
     private string $path = '';
     private string $query = '';
     private string $fragment = '';


### PR DESCRIPTION
Corrigido bug na tipagem do atributo port da classe Uri que só estava permitindo o tipo string e int, foi adicionado o tipo null para o caso não seja passado valor para esse atributo.